### PR TITLE
feat: add preview highlighting and ghost text support

### DIFF
--- a/lua/snippets/config/init.lua
+++ b/lua/snippets/config/init.lua
@@ -8,6 +8,9 @@ local defaults = {
 	--- Should an autocmd be created to load snippets automatically?
 	---@type boolean
 	create_autocmd = false,
+	--- Wrap the preview text in a markdown code block for highlighting?
+	---@type boolean
+	highlight_preview = true,
 	--- Should the cmp source be created and registered?
 	--- The created source name is "snippets"
 	---@type boolean

--- a/lua/snippets/utils/cmp.lua
+++ b/lua/snippets/utils/cmp.lua
@@ -45,7 +45,9 @@ function source:complete(_, callback)
 				table.insert(response, {
 					label = p,
 					kind = cmp.lsp.CompletionItemKind.Snippet,
-					insertText = p,
+					insertTextFormat = cmp.lsp.InsertTextFormat.Snippet,
+					insertTextMode = cmp.lsp.InsertTextMode.AdjustIndentation,
+					insertText = body,
 					data = {
 						prefix = p,
 						body = body,
@@ -56,7 +58,9 @@ function source:complete(_, callback)
 			table.insert(response, {
 				label = prefix,
 				kind = cmp.lsp.CompletionItemKind.Snippet,
-				insertText = prefix,
+				insertTextFormat = cmp.lsp.InsertTextFormat.Snippet,
+				insertTextMode = cmp.lsp.InsertTextMode.AdjustIndentation,
+				insertText = body,
 				data = {
 					prefix = prefix,
 					body = body,
@@ -68,21 +72,20 @@ function source:complete(_, callback)
 end
 
 function source:resolve(completion_item, callback)
+	-- highlight code block
+	local preview = completion_item.data.body
+	if require("snippets.config").get_option("highlight_preview", false) then
+		preview = string.format("```%s\n%s\n```", vim.bo.filetype, preview)
+	end
 	completion_item.documentation = {
 		kind = cmp.lsp.MarkupKind.Markdown,
-		value = completion_item.data.body,
+		value = preview,
 	}
 	callback(completion_item)
 end
 
 function source:execute(completion_item, callback)
 	callback(completion_item)
-	local cursor = vim.api.nvim_win_get_cursor(0)
-	cursor[1] = cursor[1] - 1
-
-	vim.api.nvim_buf_set_text(0, cursor[1], cursor[2] - #completion_item.data.prefix, cursor[1], cursor[2], { "" })
-	---@diagnostic disable-next-line: param-type-mismatch
-	vim.snippet.expand(completion_item.data.body)
 end
 
 local function register()


### PR DESCRIPTION
There are a few changes in this PR (let me know if you want me to split them up), all related to improving the cmp source.

1. Use the body for `insertText` instead of `prefix`, to allow showing a preview as ghost text instead of just showing the prefix.
2. Use the `InsertTextFormat.snippet` to invoke `cmp`'s snippet expansion instead of using `vim.snippet` directly (users will have configured cmp to expand via vim.snippet).
3. Adds markdown code block surrounding the preview body to allow treesitter highlighting of code previews (can be disabled via an option)