### PR TITLE
fix: stop cmp source when there is no loaded snippets

### DIFF
--- a/lua/snippets/utils/cmp.lua
+++ b/lua/snippets/utils/cmp.lua
@@ -28,6 +28,10 @@ function source:complete(_, callback)
 
 	local loaded_snippets = cache[vim.bo.filetype]
 
+	if loaded_snippets == nil then
+		return
+	end
+
 	local response = {}
 
 	for key in pairs(loaded_snippets) do


### PR DESCRIPTION
Fixes #8 