### PR TITLE
fix: gather all snippets for a filetype. Don't override.

### DIFF
--- a/lua/snippets/utils/init.lua
+++ b/lua/snippets/utils/init.lua
@@ -60,13 +60,11 @@ function utils.register_snippets()
 				return
 			end
 
+			Snippets.registry[key] = Snippets.registry[key] or {}
 			if type(file) == "table" then
-				Snippets.registry[key] = utils.normalize_table(Snippets.registry[key])
-				for _, f in ipairs(file) do
-					table.insert(Snippets.registry[key], f)
-				end
+				vim.list_extend(Snippets.registry[key], file)
 			else
-				Snippets.registry[key] = file
+				table.insert(Snippets.registry[key], file)
 			end
 		end
 	end


### PR DESCRIPTION
Right now, when you have a custom snippet for which also a friendly snippets file exists, the custom one would be overwritte.

For example with a custom `snippets/gitcommit.json`

This PR fixes that