### PR TITLE
fix/handle symlinks

### DIFF
--- a/lua/snippets/utils/init.lua
+++ b/lua/snippets/utils/init.lua
@@ -53,7 +53,11 @@ function utils.scan_for_snippets(dir, result)
 		for name, ftype in iter do
 			local path = string.format("%s/%s", dir, name)
 
-			utils.scan_for_snippets(path, result)
+			if ftype == "directory" then
+				result[name] = utils.scan_for_snippets(path, result[name] or {})
+			else
+				utils.scan_for_snippets(path, result)
+			end
 		end
 	elseif stat.type == "file" then
 		local name = vim.fn.fnamemodify(dir, ":t")


### PR DESCRIPTION
### Overview
This pull request primarily adds proper handling of symlinks, while also improving `scan_for_snippets`.

This pull request introduces a new `.editorconfig` file to standardize coding styles across the project and refactors the `scan_for_snippets` function in `lua/snippets/utils/init.lua` to improve its functionality and readability.

### Key changes

#### Configuration
- **Added `.editorconfig` file**: This file is used to standardize coding styles across the project and enforce consistent formatting.

#### Code Refactoring
- **Updated `scan_for_snippets` function**:
  - Changed the return type annotation to `string[]`.
  - Replaced `vim.uv.fs_scandir` with `vim.uv.fs_stat` to check the type of the directory entry.
  - Added handling for different types of directory entries:
    - **Directory**: Recursively scan for snippets.
    - **File**: Check if the file has a `.json` extension and add it to the result.
    - **Link**: Resolve the link and scan the target.

- **Fixed indentation**:
  - Corrected indentation in the `register_cmp_source` function to use tabs instead of spaces.
