### PR TITLE
fix: use list_runtime_paths api

### DIFF
--- a/lua/snippets/utils/init.lua
+++ b/lua/snippets/utils/init.lua
@@ -203,7 +203,7 @@ end
 
 function utils.load_friendly_snippets()
 	local search_paths = Snippets.config.get_option("search_paths", {})
-	for _, path in ipairs(vim.opt.runtimepath:get()) do
+	for _, path in ipairs(vim.api.nvim_list_runtime_paths()) do
 		if string.match(path, "friendly.snippets") then
 			table.insert(search_paths, string.format("%s/snippets", path))
 		end


### PR DESCRIPTION
Using the `nvim_list_runtime_paths` produce more accurate results for each loaded plugin. This also fixes the issue for Nix users using friendly-snippets.