### PR TITLE
feat(cmp): use parsed snippet for cmp documentation

### DIFF
--- a/lua/snippets/utils/cmp.lua
+++ b/lua/snippets/utils/cmp.lua
@@ -1,4 +1,5 @@
 local cmp = require("cmp")
+local utils = require("snippets.utils")
 
 local source = {}
 
@@ -67,7 +68,7 @@ end
 
 function source:resolve(completion_item, callback)
 	-- highlight code block
-	local preview = completion_item.data.body
+	local preview = utils.preview(completion_item.data.body)
 	if require("snippets.config").get_option("highlight_preview", false) then
 		preview = string.format("```%s\n%s\n```", vim.bo.filetype, preview)
 	end

--- a/lua/snippets/utils/init.lua
+++ b/lua/snippets/utils/init.lua
@@ -265,6 +265,11 @@ local function resolve_variable(input, name, replacement)
 	return input:gsub("%$[{]?(" .. name .. ")[}]?", replacement)
 end
 
+function utils.preview(snippet)
+	local parse = safe_parse(utils.expand_vars(snippet))
+	return parse and tostring(parse) or snippet
+end
+
 ---@type fun(snippet: string): string
 function utils.expand_vars(input)
 	local lazy_vars = Snippets.utils.builtin_vars.lazy


### PR DESCRIPTION
This PR uses the parsed snippet as documentation instead of the raw snippet.

# With this PR
![image](https://github.com/garymjr/nvim-snippets/assets/292349/433d421d-3570-43bf-a6f3-6377d922ab78)

# Before
![image](https://github.com/garymjr/nvim-snippets/assets/292349/8ee7f1cc-698c-4b68-bc1e-bb76abf974a8)

Edit: not the same snippet, but you get the idea :)