### PR TITLE
docs(readme): mark package.json support TODO as completed

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,4 +91,4 @@ search_paths       | `string[]`  | `{vim.fn.stdpath('config') .. '/snippets'}` |
 
 ## TODO
 - [ ] Automatically detect if friendly-snippets is installed
-- [ ] (Undecided) Add support for friendly-snippets `package.json` definitions
+- [X] Add support for friendly-snippets `package.json` definitions (#31)


### PR DESCRIPTION
Support for `package.json` filetype definitions was completed in #31.
