### PR TITLE
feature: expand or jump

### DIFF
--- a/lua/snippets/init.lua
+++ b/lua/snippets/init.lua
@@ -62,6 +62,26 @@ function snippets.get_loaded_snippets()
 	return snippets.loaded_snippets
 end
 
+function snippets.expand_or_jump()
+	if vim.snippet.active({ direction = 1 }) then
+		return vim.schedule(function()
+			vim.snippet.jump(1)
+		end)
+	end
+	-- code
+	local snippet, prefix = snippets.utils.get_snippet_at_cursor(snippets.loaded_snippets)
+
+	if type(snippet) ~= "string" then
+		return
+	end
+
+	vim.schedule(function()
+		local lnum, col = unpack(vim.api.nvim_win_get_cursor(0))
+		vim.api.nvim_buf_set_text(0, lnum - 1, col - #prefix, lnum - 1, col, {})
+		vim.snippet.expand(snippet)
+	end)
+end
+
 ---@param opts? table  -- Make a better type for this
 function snippets.setup(opts)
 	snippets.config.new(opts)

--- a/lua/snippets/utils/init.lua
+++ b/lua/snippets/utils/init.lua
@@ -341,4 +341,42 @@ function utils.find_snippet_prefix(prefix)
 	return Snippets.loaded_snippets[prefix]
 end
 
+---@type fun(snippets: table<string, table>|nil, prefix: string): table|nil
+local function get_snippet_by_prefix(snippets, prefix)
+	if not snippets then
+		return nil
+	end
+
+	for _, value in pairs(snippets) do
+		if value.prefix == prefix then
+			return value
+		end
+	end
+
+	return nil
+end
+
+---@type fun(snippets: table<string, table>|nil): string|nil, string
+function utils.get_snippet_at_cursor(snippets)
+	local line = vim.api.nvim_get_current_line()
+	local offset = vim.fn.mode() == "i" and 0 or 1
+	local col = vim.api.nvim_win_get_cursor(0)[2] + offset
+
+	-- TODO: Probably make matching character configurable
+	local prefix = line:sub(1, col):match("[%w_-.]*$")
+	local res = get_snippet_by_prefix(snippets, prefix)
+
+	if not res then
+		return nil, prefix
+	end
+
+	if vim.is_callable(res.body) then
+		return res.body(), prefix
+	elseif type(res.body) == "table" then
+		return table.concat(res.body, "\n"), prefix
+	end
+
+	return res.body, prefix
+end
+
 return utils


### PR DESCRIPTION
Hi, In Luasnip, I prefer using `<C-j>` and `<C-k>` for snippet expanding/jumping. But here We can only jump if snippet already expanded. I didn't find anything that can solve my problem.

If I don't use cmp then how we can expand snippet ?

If `req` is a snippet for `require()` then after typing `req` then If I press <C-j>, it should expand snippet.

This is the pull request what I have added in my nvim config. May be I was wrong. May be there is a better way to do this. I am new in Neovim. Sorry If I make something wrong.

Here is my `<C-j>` and `<C-k>` mapping.

```lua
vim.keymap.set({ "i", "s" }, "<C-j>", function()
  require("snippets").expand_or_jump()
end, { desc = "Snippet Expand/Jump Next" })

vim.keymap.set({ "i", "s" }, "<C-k>", function()
  if vim.snippet.active({ direction = -1 }) then
    vim.schedule(function()
      vim.snippet.jump(-1)
    end)
  end
end, { desc = "Snippet Jump Prev" })
```

Just add this feature if it's missing.

Thanks