### PR TITLE
Make friendly-snippets overridable

### DIFF
--- a/lua/snippets/utils/init.lua
+++ b/lua/snippets/utils/init.lua
@@ -324,7 +324,7 @@ function utils.load_friendly_snippets()
 	local search_paths = Snippets.config.get_option("search_paths", {})
 	for _, path in ipairs(vim.api.nvim_list_runtime_paths()) do
 		if string.match(path, "friendly.snippets") then
-			table.insert(search_paths, path)
+			table.insert(search_paths, 1, path)
 		end
 	end
 	Snippets.config.set_option("search_paths", search_paths)


### PR DESCRIPTION
friendly-snippets is a third-part library which can not be modified freely as it's need update to date. Snippets should be able to improved in your own snippets repo.