### PR TITLE
feat: add native completion support for snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,15 +68,16 @@ Using [lazy.nvim](https://github.com/folke/lazy.nvim)
 
 ## Configuration
 
-| Option           | Type      | Default                                   | Description           |
--------------------|-----------|-------------------------------------------|------------------------
-create_autocmd     | `boolean?`  | `false`                                     | Optionally load all snippets when opening a file. Only needed if not using [nvim-cmp](https://github.com/hrsh7th/nvim-cmp).
-create_cmp_source  | `boolean?`  | `true`                                      | Optionally create a [nvim-cmp](https://github.com/hrsh7th/nvim-cmp) source. Source name will be `snippets`.
-friendly_snippets  | `boolean?`  | `false`                                     | Set to true if using [friendly-snippets](https://github.com/rafamadriz/friendly-snippets).
-ignored_filetypes  | `string[]?` | `nil`                                       | Filetypes to ignore when loading snippets.
-extended_filetypes | `table?`    | `nil`                                       | Filetypes to load snippets for in addition to the default ones. `ex: {typescript = {'javascript'}}`
-global_snippets    | `string[]?` | `{'all'}`                                   | Snippets to load for all filetypes.
-search_paths       | `string[]`  | `{vim.fn.stdpath('config') .. '/snippets'}` | Paths to search for snippets.
+| Option                  | Type      | Default                                   | Description           |
+--------------------------|-----------|-------------------------------------------|------------------------
+create_autocmd            | `boolean?`  | `false`                                     | Optionally load all snippets when opening a file. Only needed if not using [nvim-cmp](https://github.com/hrsh7th/nvim-cmp).
+create_cmp_source         | `boolean?`  | `true`                                      | Optionally create a [nvim-cmp](https://github.com/hrsh7th/nvim-cmp) source. Source name will be `snippets`.
+create_native_completion  | `boolean?`  | `false`                                     | Optionally create a native completion function for snippets. Function name will be `nvim_snippets_complete`.
+friendly_snippets         | `boolean?`  | `false`                                     | Set to true if using [friendly-snippets](https://github.com/rafamadriz/friendly-snippets).
+ignored_filetypes         | `string[]?` | `nil`                                       | Filetypes to ignore when loading snippets.
+extended_filetypes        | `table?`    | `nil`                                       | Filetypes to load snippets for in addition to the default ones. `ex: {typescript = {'javascript'}}`
+global_snippets           | `string[]?` | `{'all'}`                                   | Snippets to load for all filetypes.
+search_paths              | `string[]`  | `{vim.fn.stdpath('config') .. '/snippets'}` | Paths to search for snippets.
 
 ## Example Snippet
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Using [lazy.nvim](https://github.com/folke/lazy.nvim)
 create_autocmd            | `boolean?`  | `false`                                     | Optionally load all snippets when opening a file. Only needed if not using [nvim-cmp](https://github.com/hrsh7th/nvim-cmp).
 create_cmp_source         | `boolean?`  | `true`                                      | Optionally create a [nvim-cmp](https://github.com/hrsh7th/nvim-cmp) source. Source name will be `snippets`.
 create_native_completion  | `boolean?`  | `false`                                     | Optionally create a native completion function for snippets. Function name will be `nvim_snippets_complete`.
+native_completion_kind    | `string?`   | `'Snippet'`                                 | The completion kind to use for the native completion function.
 friendly_snippets         | `boolean?`  | `false`                                     | Set to true if using [friendly-snippets](https://github.com/rafamadriz/friendly-snippets).
 ignored_filetypes         | `string[]?` | `nil`                                       | Filetypes to ignore when loading snippets.
 extended_filetypes        | `table?`    | `nil`                                       | Filetypes to load snippets for in addition to the default ones. `ex: {typescript = {'javascript'}}`

--- a/lua/snippets/config/init.lua
+++ b/lua/snippets/config/init.lua
@@ -15,6 +15,10 @@ local defaults = {
 	--- The created source name is "snippets"
 	---@type boolean
 	create_cmp_source = true,
+	--- Should the global function for native completion be created?
+	--- The created function name is "nvim_snippets_complete"
+	---@type boolean
+	create_native_completion = false,
 	--- Should we try to load the friendly-snippets snippets?
 	---@type boolean
 	friendly_snippets = false,

--- a/lua/snippets/config/init.lua
+++ b/lua/snippets/config/init.lua
@@ -19,6 +19,9 @@ local defaults = {
 	--- The created function name is "nvim_snippets_complete"
 	---@type boolean
 	create_native_completion = false,
+	--- The completion item kind to use for native completion items
+	--- @type string
+	native_completion_kind = "Snippet",
 	--- Should we try to load the friendly-snippets snippets?
 	---@type boolean
 	friendly_snippets = false,

--- a/lua/snippets/init.lua
+++ b/lua/snippets/init.lua
@@ -78,6 +78,10 @@ function snippets.setup(opts)
 	if snippets.config.get_option("create_cmp_source") then
 		snippets.utils.register_cmp_source()
 	end
+
+	if snippets.config.get_option("create_native_completion") then
+		snippets.utils.register_native_completion()
+	end
 end
 
 return snippets

--- a/lua/snippets/utils/init.lua
+++ b/lua/snippets/utils/init.lua
@@ -321,7 +321,9 @@ function utils.register_cmp_source()
 end
 
 function utils.register_native_completion()
-	require("snippets.utils.native-completion").register()
+	require("snippets.utils.native-completion").register(
+		Snippets.config.get_option("native_completion_kind", "Snippet")
+	)
 end
 
 function utils.load_friendly_snippets()

--- a/lua/snippets/utils/init.lua
+++ b/lua/snippets/utils/init.lua
@@ -320,6 +320,10 @@ function utils.register_cmp_source()
 	require("snippets.utils.cmp").register()
 end
 
+function utils.register_native_completion()
+	require("snippets.utils.native-completion").register()
+end
+
 function utils.load_friendly_snippets()
 	local search_paths = Snippets.config.get_option("search_paths", {})
 	for _, path in ipairs(vim.api.nvim_list_runtime_paths()) do

--- a/lua/snippets/utils/native-completion.lua
+++ b/lua/snippets/utils/native-completion.lua
@@ -82,12 +82,8 @@ local function register()
 			end
 
 			-- Get current line and cursor position
-			local line = vim.api.nvim_get_current_line()
-			local col = vim.api.nvim_win_get_cursor(0)[2]
-			local start_col = col - word:len()
-
-			line = line:sub(1, start_col)
-			vim.api.nvim_set_current_line(line)
+			local lnum, col = unpack(vim.api.nvim_win_get_cursor(0))
+			vim.api.nvim_buf_set_text(0, lnum - 1, col - #word, lnum - 1, col, {})
 			vim.snippet.expand(completed.user_data.body)
 		end,
 	})

--- a/lua/snippets/utils/native-completion.lua
+++ b/lua/snippets/utils/native-completion.lua
@@ -8,7 +8,7 @@ local function get_snippet_body(snippet)
 	end
 end
 
-local function snippet_to_complete_items(prefix, snippet)
+local function snippet_to_complete_items(prefix, snippet, kind)
 	local body = get_snippet_body(snippet)
 	local preview = utils.preview(body)
 	if require("snippets.config").get_option("highlight_preview", false) then
@@ -28,7 +28,7 @@ local function snippet_to_complete_items(prefix, snippet)
 		word = prefix,
 		abbr = prefix .. "~",
 		info = info,
-		kind = "Snippet",
+		kind = kind,
 		user_data = {
 			nvim_snippet = true,
 			prefix = prefix,
@@ -39,7 +39,9 @@ local function snippet_to_complete_items(prefix, snippet)
 	}
 end
 
-local function register()
+--- The function to register the global completion function and the autocmd to expand snippets on completion
+--- @param kind string The completion item kind to use for native completion items
+local function register(kind)
 	--- Complete function for snippets
 	--- @param findstart number 1 to find start position, 0 to find matches
 	--- @param base string The text to match (empty on first call)
@@ -63,10 +65,10 @@ local function register()
 				local prefix = snippet.prefix
 				if type(prefix) == "table" then
 					for _, p in ipairs(prefix) do
-						table.insert(response, snippet_to_complete_items(p, snippet))
+						table.insert(response, snippet_to_complete_items(p, snippet, kind))
 					end
 				else
-					table.insert(response, snippet_to_complete_items(prefix, snippet))
+					table.insert(response, snippet_to_complete_items(prefix, snippet, kind))
 				end
 			end
 			return response

--- a/lua/snippets/utils/native-completion.lua
+++ b/lua/snippets/utils/native-completion.lua
@@ -1,0 +1,96 @@
+local utils = require("snippets.utils")
+
+local function get_snippet_body(snippet)
+	if type(snippet.body) == "table" then
+		return table.concat(snippet.body, "\n")
+	else
+		return snippet.body
+	end
+end
+
+local function snippet_to_complete_items(prefix, snippet)
+	local body = get_snippet_body(snippet)
+	local preview = utils.preview(body)
+	if require("snippets.config").get_option("highlight_preview", false) then
+		preview = string.format("```%s\n%s\n```", vim.bo.filetype, preview)
+	end
+	local description = snippet.description and snippet.description .. "\n\n" or ""
+	local info = string.format("%s%s", description or "", preview)
+
+	return {
+		word = prefix,
+		abbr = prefix .. "~",
+		info = info,
+		kind = "Snippet",
+		user_data = {
+			nvim_snippet = true,
+			prefix = prefix,
+			body = body,
+		},
+		dup = 1,
+		icase = 1,
+	}
+end
+
+local function register()
+	--- Complete function for snippets
+	--- @param findstart number 1 to find start position, 0 to find matches
+	--- @param base string The text to match (empty on first call)
+	--- @return number|table Column position on first call, list of matches on second call
+	_G.nvim_snippets_complete = function(findstart, base)
+		if findstart == 1 then
+			-- First call: find the start of the completion
+			local col = vim.api.nvim_win_get_cursor(0)[2]
+
+			return col
+		else
+			local loaded_snippets = Snippets.load_snippets_for_ft(vim.bo.filetype)
+			if loaded_snippets == nil then
+				return {}
+			end
+
+			local response = {}
+			for key in pairs(loaded_snippets) do
+				local snippet = loaded_snippets[key]
+
+				local prefix = snippet.prefix
+				if type(prefix) == "table" then
+					for _, p in ipairs(prefix) do
+						table.insert(response, snippet_to_complete_items(p, snippet))
+					end
+				else
+					table.insert(response, snippet_to_complete_items(prefix, snippet))
+				end
+			end
+			return response
+		end
+	end
+
+	vim.api.nvim_create_autocmd("CompleteDone", {
+		group = vim.api.nvim_create_augroup("_nvim_snippet_complete", { clear = true }),
+		callback = function()
+			local completed = vim.v.completed_item
+			local word = completed.word
+			local reason = vim.v.event.reason
+
+			if not word or reason ~= "accept" then
+				return
+			end
+
+			if not completed.user_data or not completed.user_data.nvim_snippet then
+				return
+			end
+
+			-- Get current line and cursor position
+			local line = vim.api.nvim_get_current_line()
+			local col = vim.api.nvim_win_get_cursor(0)[2]
+			local start_col = col - word:len()
+
+			line = line:sub(1, start_col)
+			vim.api.nvim_set_current_line(line)
+			vim.snippet.expand(completed.user_data.body)
+		end,
+	})
+end
+
+return { register = register }

--- a/lua/snippets/utils/native-completion.lua
+++ b/lua/snippets/utils/native-completion.lua
@@ -14,7 +14,14 @@ local function snippet_to_complete_items(prefix, snippet)
 	if require("snippets.config").get_option("highlight_preview", false) then
 		preview = string.format("```%s\n%s\n```", vim.bo.filetype, preview)
 	end
-	local description = snippet.description and snippet.description .. "\n\n" or ""
+	local description = ""
+	if snippet.description then
+		local string_description = snippet.description
+		if type(snippet.description) == "table" then
+			string_description = table.concat(snippet.description, "\n")
+		end
+		description = string_description .. "\n\n"
+	end
 	local info = string.format("%s%s", description or "", preview)
 
 	return {


### PR DESCRIPTION
Add configuration option `create_native_completion` to enable native Neovim completion integration for snippets. When enabled, creates a global `nvim_snippets_complete` function that can be used with Neovim's built-in completion system.

The implementation:
- Adds new config option `create_native_completion` (default: false)
- Converts snippets to native completion items with preview
- Handles CompleteDone autocmd to expand accepted snippets

This allows users to integrate snippet completion without requiring external completion frameworks like nvim-cmp.

After `:set complete=Fv:lua.nvim_snippets_complete` we see:

<img width="397" height="293" alt="image" src="https://github.com/user-attachments/assets/d19b5b9d-77c1-4682-803f-6be0e35a5c32" />
<img width="564" height="297" alt="image" src="https://github.com/user-attachments/assets/704a7991-be98-4cb1-9047-9294f9469813" />
<img width="168" height="122" alt="image" src="https://github.com/user-attachments/assets/58623d48-64bd-4dbf-a35d-0231ef203399" />
